### PR TITLE
Fixes scheduling bug where the next prompt arrives immediately

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,6 +6,7 @@ var promptsUnansweredDB = db.register('prompts-unanswered');
 var promptsAnsweredDB = db.register('prompts-answered');
 var promptsMetadataDB = db.register('prompts-metadata');
 var scheduler = require('level-schedule')(db.register('prompt-scheduler'));
+var random = require('./random');
 
 var chooser = require('./prompt-chooser');
 var User = require('./user');
@@ -41,8 +42,7 @@ exports.schedule = function(userHash, cb) {
     var max = conf.get('maxTimeBetweenPrompts');
     var min = conf.get('minTimeBetweenPrompts');
 
-    var arriveIn = Math.random() * max - min;
-
+    var arriveIn = random().nextInt(min, max);
     var arriveAt = Date.now() + arriveIn;
 
     debug(


### PR DESCRIPTION
@kirbysayshi 

Replaces Math.random() with arbit as the prng.

To see why:

```
min = 45 minutes = 2700000 ms
max = 3 hours = 10800000 ms
```

Suppose `Math.random()` is 0.1. Then,

```
0.1 * 10800000 - 2700000 = 1080000 - 2700000 = -1620000
```
